### PR TITLE
Add docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,5 @@ RUN apt-get update && apt-get install -y libxrender-dev
 RUN mkdir /my_data
 
 EXPOSE 8888
+
+CMD jupyter notebook --notebook-dir=/tmp --ip=* --allow-root

--- a/README.md
+++ b/README.md
@@ -55,3 +55,28 @@ If you are running any other processes on port 8888 (e.g. another Jupyter notebo
 ## Acknowledgement
 
 This implementation was forked from Greg Landrum's [rdkit containers](https://github.com/rdkit/rdkit_containers/tree/master/docker/run_conda3) repo, but I've tweaked it a bit and updated the things that didn't work for me initially, in hopes to provide an "out of the box" build, relevant to May 2018 developers. All credit goes to Greg and the other RDKit devs.
+
+
+Docker Compose
+===
+
+Once steps 1 and 2 of the [Instuctions](#instructions) sections have been
+completed you can use docker-compose to complete steps 3-7:
+
+Step 3:
+
+```bash
+docker-compose --build
+```
+
+Step 4-7:
+```bash
+# start container with logs output to terminal
+docker-compose up
+
+# or start container in background
+docker-compose up -d
+
+# output the container logs
+docker-compose logs -f
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  notebook:
+    build: .
+    image: simonkeng/rdkit-jupyter-docker
+    ports:
+      - "8888:8888"


### PR DESCRIPTION
Running docker commands with args can be a little intimidating for users
who are either new to a CLI and/or Docker.

The Dockerfile has also been updated with a CMD instruction which can be
overiden but allows for simply running 'docker run <image>' or
`docker-compose up`

The README has been updated with instructions on starting and accessing the notebook
container.

Resolves #1