### PR TITLE
Changes for jupyter/notebook 5.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN mkdir /my_data
 
 EXPOSE 8888
 
-CMD jupyter notebook --notebook-dir=/tmp --ip=* --allow-root
+CMD jupyter notebook --notebook-dir=/tmp --ip='0.0.0.0' --allow-root


### PR DESCRIPTION
There's a breaking change jupyter/notebooks which only affects users pulling/building a new image introduced in:

```bash
$ jupyter notebook --version
5.7.0
```

change the *ip* option to the `jupyter notebook` command because of
error at image build time.

Fixes: Issue #3

Reference: jupyter/notebook#3946
This basically is broken in 